### PR TITLE
TeleopShooter

### DIFF
--- a/src/main/java/com/team1389/systems/TeleopShooter.java
+++ b/src/main/java/com/team1389/systems/TeleopShooter.java
@@ -33,19 +33,19 @@ public class TeleopShooter extends Subsystem
      */
 
     public TeleopShooter(DigitalOut rightShooter, DigitalOut leftShooter, 
-        DigitalIn shootRightBtn, DigitalIn shootLeftB, DigitalIn hasCargo)
+        DigitalIn shootRightBtn, DigitalIn shootLeftBtn, DigitalIn hasCargo)
     {
         this.rightShooter = rightShooter;
         this.leftShooter = leftShooter;
         this.hasCargo = hasCargo;
+        this.shootRightBtn = shootRightBtn;
+        this.shootLeftBtn = shootLeftBtn;
     }
 
     public TeleopShooter(DigitalOut rightShooter, DigitalOut leftShooter, 
-    DigitalIn shootRightButton, DigitalIn shootLeftButton) {
-        this.rightShooter = rightShooter;
-        this.leftShooter = leftShooter;
-        this.shootLeftBtn = shootLeftBtn;
-        this.shootRightBtn = shootLeftBtn;
+    DigitalIn shootRightBtn, DigitalIn shootLeftBtn) {
+        this(rightShooter, leftShooter, shootRightBtn, shootLeftBtn, null);
+        System.err.println("Teleop shooter initialized without cargo sensor - brace for a NullPointerException");
     }
     public AddList<Watchable> getSubWatchables(AddList<Watchable> stem)
     {


### PR DESCRIPTION
Somehow there are spelling errors in [TeleopShooter](https://github.com/team1389/Robot-2019/blob/master/src/main/java/com/team1389/systems/TeleopShooter.java)'s constructors, making them visibly broken. No idea how we didn't catch this earlier, but here's a fix.